### PR TITLE
rewritev2: alternate approache to get dirname where i don't hate the …

### DIFF
--- a/include/internal/fetchers/contest.hh
+++ b/include/internal/fetchers/contest.hh
@@ -18,6 +18,8 @@ namespace cmpt {
         std::vector<one>& expose_contest() {
             return cntst_problems;
         }
+
+
         std::optional<bool> get_data_contest();
     private:
         std::optional<bool> wrangle_contest(crow::json::rvalue& json_data, uint16_t& received_blocks);

--- a/include/internal/fetchers/one.hh
+++ b/include/internal/fetchers/one.hh
@@ -20,6 +20,7 @@ namespace cmpt {
 
         friend class contest;
     private:
+        void process_url(std::string& url);
         std::optional<bool> wrangle(const crow::json::rvalue& json_data);
         constexpr static bool is_one = true;
         problem prob;

--- a/include/internal/models/problem_model.hh
+++ b/include/internal/models/problem_model.hh
@@ -28,6 +28,7 @@ namespace cmpt {
         std::string testType;           // Type of the tests (single or multiNumber). TODO Figure out what to do about multiNumber
         __batch batch;                  // Batch information
         uint32_t numTestCases;
+        std::vector<std::string> url_vec; // parts of the url to avoid the bug for dir_name.
 
 
         // Not using the following options for now.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,6 @@ int main() {
     cmpt::one aprob;
     cmpt::config cnf;
     cmpt::execf exe;
-    exe.execute_one_ult(cnf, aprob, false);
-    // exe.execute_contest_ult(cnf);
+    // exe.execute_one_ult(cnf, aprob, false);
+    exe.execute_contest_ult(cnf);
 }


### PR DESCRIPTION
Bugfix: Alternate way to do the dirname fetching by splitting url when receiving it for the first time. Although this involves more code but saves the trouble of thinking in terms of offsets via rfind() calls.